### PR TITLE
Adicionar verificação de variáveis de ambiente

### DIFF
--- a/bot_telegram.py
+++ b/bot_telegram.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 import os
 from pathlib import Path
-from dotenv import load_dotenv
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.ext import ApplicationBuilder, CommandHandler, CallbackQueryHandler, ContextTypes
+
+from utils import verificar_env
 
 from escritor_ia import gerar_post, salvar_post
 from imagem_ia import gerar_imagem
 
-load_dotenv()
+verificar_env()
 TOKEN = os.getenv("TELEGRAM_TOKEN")
 
 

--- a/escritor_ia.py
+++ b/escritor_ia.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import os
 from datetime import datetime
 from pathlib import Path
-from dotenv import load_dotenv
+from utils import verificar_env
 import openai
 from jinja2 import Template
 
@@ -10,7 +10,7 @@ ESTILO_PATH = Path("prompts/estilo.txt")
 TEMPLATE_PATH = Path("templates/artigo.md")
 OUTPUT_DIR = Path("conteudos_gerados")
 
-load_dotenv()
+verificar_env()
 openai.api_key = os.getenv("OPENAI_API_KEY")
 
 

--- a/imagem_ia.py
+++ b/imagem_ia.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 import os
 from pathlib import Path
-from dotenv import load_dotenv
+from utils import verificar_env
 import openai
 import requests
 
-load_dotenv()
+verificar_env()
 openai.api_key = os.getenv("OPENAI_API_KEY")
 
 

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+import os
+import sys
+from dotenv import load_dotenv
+
+
+def verificar_env() -> None:
+    """Verifica se as variáveis necessárias estão definidas.
+
+    Exige TELEGRAM_TOKEN e OPENAI_API_KEY. Caso alguma esteja ausente,
+    uma mensagem amigável é exibida e o programa é encerrado.
+    """
+    load_dotenv()
+    faltantes = [var for var in ("TELEGRAM_TOKEN", "OPENAI_API_KEY") if not os.getenv(var)]
+    if faltantes:
+        nomes = ", ".join(faltantes)
+        print(
+            f"Erro: defina as variáveis de ambiente {nomes} "
+            "(arquivo .env ou variáveis do sistema)."
+        )
+        sys.exit(1)
+


### PR DESCRIPTION
## Summary
- criar utilitário `verificar_env` para validar `TELEGRAM_TOKEN` e `OPENAI_API_KEY`
- usar o utilitário no início de `bot_telegram.py`, `escritor_ia.py` e `imagem_ia.py`

## Testing
- `python -m py_compile bot_telegram.py escritor_ia.py imagem_ia.py utils.py gerador_tendencias.py`

------
https://chatgpt.com/codex/tasks/task_e_683fb9c5c880832ab90a79b9983ae067