### PR TITLE
Add translated news titles

### DIFF
--- a/bot_telegram.py
+++ b/bot_telegram.py
@@ -27,6 +27,7 @@ from escritor_ia import (
 )
 from imagem_ia import gerar_imagem
 from gerador_tendencias import obter_tendencias
+from tradutor import traduzir_para_pt
 
 # Configuração de logging mais detalhada
 logging.basicConfig(
@@ -277,6 +278,8 @@ async def tendencias(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
             # Criar apenas os botões para cada tendência
             keyboard = []
 
+            msg_linhas = ["📈 **Tendências Atuais**", ""]
+
             for i, t in enumerate(topicos):
                 # Armazenar tanto título original quanto resumo
                 cache_key = f"{update.effective_chat.id}_{i}"
@@ -306,8 +309,17 @@ async def tendencias(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
                     ]
                 )
 
+                try:
+                    traducao = traduzir_para_pt(t.titulo)
+                except Exception:
+                    traducao = t.titulo
+                msg_linhas.append(f"{i+1}. {t.titulo} - {traducao}")
+
+            msg_linhas.append("")
+            msg_linhas.append("👆 *Clique para gerar post:*")
+
             await processing_msg.edit_text(
-                "📈 **Tendências Atuais**\n\n👆 *Clique para gerar post:*",
+                "\n".join(msg_linhas),
                 reply_markup=InlineKeyboardMarkup(keyboard),
                 parse_mode="Markdown",
             )

--- a/docker-requirements.txt
+++ b/docker-requirements.txt
@@ -4,3 +4,4 @@ python-dotenv==1.0.0
 python-telegram-bot==20.3
 pytrends==4.9.2
 requests==2.31.0
+deep-translator==1.11.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pytrends==4.9.2
 jinja2==3.1.2
 Pillow==10.1.0
 httpx==0.24.1
+deep-translator==1.11.4

--- a/tests/test_gerador_tendencias.py
+++ b/tests/test_gerador_tendencias.py
@@ -6,6 +6,7 @@ from gerador_tendencias import (
     HN_ITEM_URL,
     HN_TOP_URL,
     REDDIT_URL,
+    TECHCRUNCH_RSS,
     Tendencia,
     obter_tendencias,
 )
@@ -42,6 +43,15 @@ def test_obter_tendencias(mock_get, mock_trendreq):
         if url == HN_ITEM_URL.format(102):
             resp.json.return_value = {"title": "HN102", "url": "http://hn102"}
             return resp
+        if url == TECHCRUNCH_RSS:
+            resp.content = (
+                "<rss><channel>"
+                "<item><title>Interesting Title One</title><link>http://t1</link></item>"
+                "<item><title>Interesting Title Two</title><link>http://t2</link></item>"
+                "</channel></rss>"
+            ).encode()
+            resp.raise_for_status = lambda: None
+            return resp
         raise RuntimeError(f"URL inesperada: {url}")
 
     mock_get.side_effect = get_side_effect
@@ -49,4 +59,12 @@ def test_obter_tendencias(mock_get, mock_trendreq):
     tendencias = obter_tendencias()
     titulos = [t.titulo for t in tendencias]
 
-    assert titulos == ["R1", "R2", "Google1", "Google2", "HN101", "HN102"]
+    esperado = {
+        "Interesting Title One",
+        "Interesting Title Two",
+        "R1",
+        "R2",
+        "HN101",
+        "HN102",
+    }
+    assert set(titulos) == esperado

--- a/tradutor.py
+++ b/tradutor.py
@@ -1,0 +1,13 @@
+import logging
+from deep_translator import GoogleTranslator
+
+_translator = GoogleTranslator(source="auto", target="pt")
+
+
+def traduzir_para_pt(texto: str) -> str:
+    """Traduz texto para português usando deep-translator."""
+    try:
+        return _translator.translate(texto)
+    except Exception:
+        logging.exception("Erro ao traduzir texto")
+        return texto


### PR DESCRIPTION
## Summary
- translate titles when listing trends
- add new translator module using deep-translator
- update dependencies
- adjust trend tests for RSS feed

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844484b0c18832ab8f467c82d621336