### PR TITLE
Add tests

### DIFF
--- a/tests/test_escritor_ia.py
+++ b/tests/test_escritor_ia.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+import sys, os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+import types
+sys.modules['openai'] = types.SimpleNamespace(OpenAI=lambda api_key=None: types.SimpleNamespace())
+os.environ.setdefault('TELEGRAM_TOKEN', 'x')
+os.environ.setdefault('OPENAI_API_KEY', 'x')
+os.environ.setdefault('OPENAI_MODEL', 'model')
+from escritor_ia import eh_url_valida, salvar_post, salvar_texto_puro
+
+
+def test_eh_url_valida():
+    assert eh_url_valida('http://example.com')
+    assert eh_url_valida('https://example.com')
+    assert not eh_url_valida('notaurl')
+
+
+def test_salvar_post(tmp_path, monkeypatch):
+    monkeypatch.setattr('escritor_ia.OUTPUT_DIR', tmp_path)
+    caminho = salvar_post('Tema Teste', 'conteudo')
+    assert caminho.exists()
+    assert caminho.read_text() == 'conteudo'
+    assert caminho.parent == tmp_path
+
+
+def test_salvar_texto_puro_remove_yaml(tmp_path, monkeypatch):
+    monkeypatch.setattr('escritor_ia.OUTPUT_DIR', tmp_path)
+    conteudo = '---\ntitle: Example\n---\n\nCorpo do post\n\n'
+    caminho = salvar_texto_puro('Tema', conteudo)
+    assert caminho.read_text() == 'Corpo do post'

--- a/tests/test_gerador_tendencias.py
+++ b/tests/test_gerador_tendencias.py
@@ -1,5 +1,6 @@
 from unittest.mock import Mock, patch
-
+import sys, os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 import pytest
 
 from gerador_tendencias import (
@@ -68,3 +69,18 @@ def test_obter_tendencias(mock_get, mock_trendreq):
         "HN102",
     }
     assert set(titulos) == esperado
+
+from gerador_tendencias import gerar_resumo_tendencia, processar_tendencia_com_conteudo, Tendencia
+
+
+def test_gerar_resumo_tendencia_curto():
+    titulo = 'Titulo Curto'
+    assert gerar_resumo_tendencia(titulo) == titulo
+
+
+def test_processar_tendencia_com_conteudo():
+    titulo = 'Titulo muito grande para testar o resumo automatico do codigo que deve truncar'
+    tendencia = Tendencia(titulo, 'http://exemplo')
+    res = processar_tendencia_com_conteudo(tendencia)
+    assert res.titulo == titulo
+    assert isinstance(res.resumo, str) and res.resumo

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -1,0 +1,34 @@
+import asyncio
+import types
+from unittest.mock import AsyncMock, MagicMock, patch
+import sys, os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import healthcheck
+
+
+def test_verificar_variaveis(monkeypatch):
+    monkeypatch.setenv('TELEGRAM_TOKEN', '1')
+    monkeypatch.setenv('OPENAI_API_KEY', '2')
+    ok, msg = healthcheck.verificar_variaveis()
+    assert ok is True
+
+
+def test_verificar_variaveis_faltando(monkeypatch):
+    monkeypatch.delenv('TELEGRAM_TOKEN', raising=False)
+    monkeypatch.setenv('OPENAI_API_KEY', '2')
+    ok, msg = healthcheck.verificar_variaveis()
+    assert not ok
+    assert 'TELEGRAM_TOKEN' in msg
+
+
+def test_verificar_bot_simples(monkeypatch):
+    monkeypatch.setenv('TELEGRAM_TOKEN', '1')
+    dummy = types.SimpleNamespace(Bot=MagicMock())
+    with patch.dict('sys.modules', {'telegram': dummy}):
+        instance = dummy.Bot.return_value
+        instance.get_me = AsyncMock(return_value=types.SimpleNamespace(username='bot'))
+        ok, msg = asyncio.get_event_loop().run_until_complete(healthcheck.verificar_bot_simples())
+        assert ok
+        assert '@bot' in msg
+        instance.get_me.assert_called_once()

--- a/tests/test_tradutor.py
+++ b/tests/test_tradutor.py
@@ -1,0 +1,18 @@
+from unittest.mock import MagicMock, patch
+import sys, os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from tradutor import traduzir_para_pt
+
+
+@patch('tradutor._translator')
+def test_traduzir_para_pt(mock_trans):
+    mock_trans.translate.return_value = 'Olá'
+    assert traduzir_para_pt('Hello') == 'Olá'
+    mock_trans.translate.assert_called_once_with('Hello')
+
+
+@patch('tradutor._translator')
+def test_traduzir_erro_retorna_original(mock_trans):
+    mock_trans.translate.side_effect = Exception('fail')
+    texto = 'Hello'
+    assert traduzir_para_pt(texto) == texto

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,24 @@
+import sys, os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+import pytest
+import utils
+
+
+def test_verificar_env_missing(monkeypatch):
+    for var in utils.REQUIRED_VARS:
+        monkeypatch.delenv(var, raising=False)
+    with pytest.raises(EnvironmentError):
+        utils.verificar_env()
+
+
+def test_verificar_env_ok(monkeypatch):
+    for var in utils.REQUIRED_VARS:
+        monkeypatch.setenv(var, 'x')
+    utils.verificar_env()
+
+
+def test_obter_modelo_openai(monkeypatch):
+    monkeypatch.delenv('OPENAI_MODEL', raising=False)
+    assert utils.obter_modelo_openai() == 'gpt-4o-mini'
+    monkeypatch.setenv('OPENAI_MODEL', 'custom')
+    assert utils.obter_modelo_openai() == 'custom'


### PR DESCRIPTION
## Summary
- add coverage for utilities
- mock translator and healthcheck logic
- cover slug and url helpers
- add extra trend generator tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68446291c3f8832ab03887747d3d10bc